### PR TITLE
Add optional dependency 'two-face' for additional syntaxes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,6 +1373,7 @@ dependencies = [
  "rust-i18n",
  "serde_json",
  "syntect",
+ "two-face 0.5.1",
  "unicode-width",
  "web-time",
 ]
@@ -1497,7 +1498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb24e1610502779b4e307c6f95da616ec7e883b67a18108cb0a036b169e50359"
 dependencies = [
  "iced_core",
- "two-face",
+ "two-face 0.4.5",
 ]
 
 [[package]]
@@ -2455,6 +2456,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,6 +3312,7 @@ dependencies = [
  "flate2",
  "fnv",
  "once_cell",
+ "onig",
  "plist",
  "regex-syntax",
  "serde",
@@ -3582,6 +3606,17 @@ name = "two-face"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e51b6e60e545cfdae5a4639ff423818f52372211a8d9a3e892b4b0761f76b2"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
+]
+
+[[package]]
+name = "two-face"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b285c51f8a6ade109ed4566d33ac4fb289fb5d6cf87ed70908a5eaf65e948e34"
 dependencies = [
  "serde",
  "serde_derive",

--- a/iced-code-editor/Cargo.toml
+++ b/iced-code-editor/Cargo.toml
@@ -14,10 +14,12 @@ categories = ["gui"]
 
 [features]
 lsp-process = ["dep:serde_json"]
+two-face = ["dep:two-face"]
 
 [dependencies]
 iced.workspace = true
 syntect = { version = "5.3", default-features = false, features = ["default-fancy"] }
+two-face = { version = "0.5", optional = true }
 web-time = "1"
 iced_font_awesome = "0.4"
 iced_aw = "0.13"

--- a/iced-code-editor/src/canvas_editor/canvas_impl.rs
+++ b/iced-code-editor/src/canvas_editor/canvas_impl.rs
@@ -1487,8 +1487,16 @@ impl canvas::Program<Message> for CodeEditor {
         let content_geometry =
             self.content_cache.draw(renderer, bounds.size(), |frame| {
                 // syntect initialization is relatively expensive; keep it global.
-                let syntax_set =
-                    SYNTAX_SET.get_or_init(SyntaxSet::load_defaults_newlines);
+                let syntax_set = SYNTAX_SET.get_or_init(|| {
+                    #[cfg(feature = "two-face")]
+                    {
+                        two_face::syntax::extra_newlines()
+                    }
+                    #[cfg(not(feature = "two-face"))]
+                    {
+                        SyntaxSet::load_defaults_newlines()
+                    }
+                });
                 let theme_set = THEME_SET.get_or_init(ThemeSet::load_defaults);
                 let syntax_theme = theme_set
                     .themes


### PR DESCRIPTION
This pull request introduces an optional dependency on the `two-face` crate and updates the syntax set initialization logic in the code editor to use `two-face` when the corresponding feature is enabled. 

Dependency and feature management:

* Added the `two-face` crate as an optional dependency and introduced a new `two-face` feature in `Cargo.toml`, allowing users to enable or disable this functionality as needed.

Syntax set initialization logic:

* Updated the initialization of the `syntax_set` in `canvas_impl.rs` to use `two_face::syntax::extra_newlines()` when the `two-face` feature is enabled, and fallback to `SyntaxSet::load_defaults_newlines()` otherwise.