### PR TITLE
feat: implement double and triple click handling in the code editor

### DIFF
--- a/iced-code-editor/src/canvas_editor/canvas_impl.rs
+++ b/iced-code-editor/src/canvas_editor/canvas_impl.rs
@@ -1840,9 +1840,16 @@ impl CodeEditor {
                         return Action::publish(message).and_capture();
                     }
 
-                    // Don't capture the event so it can bubble up for focus management
-                    // This implements focus event propagation through the widget hierarchy
-                    Action::publish(Message::MouseClick(position))
+                    let click_count = self.classify_click(position);
+                    match click_count {
+                        2 => Action::publish(Message::DoubleClick(position))
+                            .and_capture(),
+                        3 => Action::publish(Message::TripleClick(position))
+                            .and_capture(),
+                        // Don't capture the event so it can bubble up for focus management
+                        // This implements focus event propagation through the widget hierarchy
+                        _ => Action::publish(Message::MouseClick(position)),
+                    }
                 })
             }
             mouse::Event::ButtonPressed(mouse::Button::Right) => {

--- a/iced-code-editor/src/canvas_editor/clipboard.rs
+++ b/iced-code-editor/src/canvas_editor/clipboard.rs
@@ -184,6 +184,11 @@ impl CodeEditor {
         // Remove all selections before inserting.
         if self.cursors.iter().any(|c| c.has_selection()) {
             self.delete_selection();
+        } else {
+            // A plain click leaves a zero-length anchor in place (see
+            // `handle_enter` in update.rs); clear it so it isn't mistaken for
+            // a real selection by a later edit.
+            self.clear_selection();
         }
 
         let cursor_count = self.cursors.len();

--- a/iced-code-editor/src/canvas_editor/cursor.rs
+++ b/iced-code-editor/src/canvas_editor/cursor.rs
@@ -480,6 +480,28 @@ impl CodeEditor {
         }
     }
 
+    /// Classifies a left-button press as a single/double/triple click.
+    ///
+    /// Consecutive presses count up as long as each one lands within 400ms
+    /// otherwise the count resets to 1. Counts
+    /// wrap back to 1 after 3, so a fourth rapid click starts a fresh
+    /// single/double/triple cycle rather than being silently ignored.
+    pub(crate) fn classify_click(&self, position: Point) -> u8 {
+        let now = Instant::now();
+        let count = match self.last_click.get() {
+            Some((time, pos, count))
+                if now.duration_since(time)
+                    < std::time::Duration::from_millis(400)
+                    && pos.distance(position) < 6.0 =>
+            {
+                if count >= 3 { 1 } else { count + 1 }
+            }
+            _ => 1,
+        };
+        self.last_click.set(Some((now, position, count)));
+        count
+    }
+
     /// Returns a scroll command to make the cursor visible.
     pub(crate) fn scroll_to_cursor(&self) -> Task<Message> {
         // Reuse memoized wrapping result so repeated scroll computations do not

--- a/iced-code-editor/src/canvas_editor/mod.rs
+++ b/iced-code-editor/src/canvas_editor/mod.rs
@@ -487,6 +487,9 @@ pub struct CodeEditor {
     /// This is updated via subscription events and used to handle modifier-dependent
     /// interactions, such as "Ctrl+Click" for jumping to a definition.
     pub(crate) modifiers: Cell<iced::keyboard::Modifiers>,
+    /// Last left-button press (time, position, consecutive count), used to
+    /// detect double/triple clicks.
+    pub(crate) last_click: Cell<Option<(Instant, iced::Point, u8)>>,
     /// The font used for rendering text
     pub(crate) font: iced::Font,
     /// IME pre-edit state (for CJK input)
@@ -733,6 +736,10 @@ pub enum Message {
     MouseHover(iced::Point),
     /// Mouse released
     MouseRelease,
+    /// Double-click: select the word under the cursor
+    DoubleClick(iced::Point),
+    /// Triple-click: select the whole line under the cursor
+    TripleClick(iced::Point),
     /// Right-clicked in the editor to position and open the context menu
     ContextMenuRequested(iced::Point),
     /// A configured context-menu action was selected.
@@ -966,6 +973,7 @@ impl CodeEditor {
             focus_locked: false,
             show_cursor: false,
             modifiers: Cell::new(iced::keyboard::Modifiers::default()),
+            last_click: Cell::new(None),
             font: iced::Font::MONOSPACE,
             ime_preedit: None,
             font_size: FONT_SIZE,

--- a/iced-code-editor/src/canvas_editor/update.rs
+++ b/iced-code-editor/src/canvas_editor/update.rs
@@ -357,6 +357,11 @@ impl CodeEditor {
         // so a single undo restores the replaced text.
         if self.cursors.iter().any(|cursor| cursor.has_selection()) {
             self.delete_selection();
+        } else {
+            // A plain click leaves a zero-length anchor in place (see
+            // `handle_enter`); clear it so it isn't mistaken for a real
+            // selection by a later edit.
+            self.clear_selection();
         }
 
         // Multi-cursor: build a sorted index list (descending document order)
@@ -406,6 +411,12 @@ impl CodeEditor {
     /// horizontal scroll when wrap is disabled)
     fn handle_tab(&mut self) -> Task<Message> {
         self.ensure_grouping_started("Tab");
+
+        // A plain click leaves a zero-length anchor in place (see
+        // `handle_enter`); clear it so it isn't mistaken for a real selection
+        // by a later edit. Tab only reaches here when there is no real
+        // selection to indent (see `IndentLines`).
+        self.clear_selection();
 
         // Multi-cursor: process in descending document order
         let mut order: Vec<usize> = (0..self.cursors.len()).collect();
@@ -756,6 +767,14 @@ impl CodeEditor {
             return self.scroll_to_cursor();
         }
 
+        // A mouse click leaves a zero-length anchor in place so a following
+        // drag can extend the selection (see `handle_enter`). Backspace must
+        // clear it before moving the caret; otherwise the anchor is left
+        // behind at the pre-edit position and a phantom one-character
+        // selection appears next to the cursor, which the next Backspace or
+        // Delete then eats instead of a single character.
+        self.clear_selection();
+
         // Multi-cursor: process in descending document order
         let mut order: Vec<usize> = (0..self.cursors.len()).collect();
         order.sort_by(|&a, &b| {
@@ -813,6 +832,11 @@ impl CodeEditor {
         if self.delete_selection_if_present() {
             return self.scroll_to_cursor();
         }
+
+        // See the matching comment in `handle_backspace`: clear any
+        // zero-length anchor left by a plain click before editing, so it
+        // can't be mistaken for a real selection on a later edit.
+        self.clear_selection();
 
         // Multi-cursor: process in descending document order
         let mut order: Vec<usize> = (0..self.cursors.len()).collect();
@@ -1745,6 +1769,56 @@ impl CodeEditor {
             }
             self.overlay_cache.clear();
         }
+        self.sync_search_match_from_primary_cursor();
+        Task::none()
+    }
+
+    /// Handles a double-click: selects the word under the cursor.
+    ///
+    /// If the click lands outside any word (e.g. on whitespace), the
+    /// selection is cleared and the caret is simply placed there.
+    fn handle_double_click_msg(&mut self, point: iced::Point) -> Task<Message> {
+        self.request_focus();
+        self.has_canvas_focus = true;
+        self.end_grouping_if_active();
+        self.cursors.remove_all_but_primary();
+        if let Some((line, col)) = self.calculate_cursor_from_point(point) {
+            let line_content = self.buffer.line(line);
+            let start = Self::word_start_in_line(line_content, col);
+            let end = Self::word_end_in_line(line_content, col);
+            let cursor = self.cursors.primary_mut();
+            if start < end {
+                cursor.anchor = Some((line, start));
+                cursor.position = (line, end);
+            } else {
+                cursor.anchor = None;
+                cursor.position = (line, col);
+            }
+        }
+        self.is_dragging = false;
+        self.show_cursor = true;
+        self.reset_cursor_blink();
+        self.overlay_cache.clear();
+        self.sync_search_match_from_primary_cursor();
+        Task::none()
+    }
+
+    /// Handles a triple-click: selects the whole line under the cursor.
+    fn handle_triple_click_msg(&mut self, point: iced::Point) -> Task<Message> {
+        self.request_focus();
+        self.has_canvas_focus = true;
+        self.end_grouping_if_active();
+        self.cursors.remove_all_but_primary();
+        if let Some((line, _col)) = self.calculate_cursor_from_point(point) {
+            let line_len = self.buffer.line_len(line);
+            let cursor = self.cursors.primary_mut();
+            cursor.anchor = Some((line, 0));
+            cursor.position = (line, line_len);
+        }
+        self.is_dragging = false;
+        self.show_cursor = true;
+        self.reset_cursor_blink();
+        self.overlay_cache.clear();
         self.sync_search_match_from_primary_cursor();
         Task::none()
     }
@@ -2718,6 +2792,8 @@ impl CodeEditor {
             Message::MouseDrag(point) => self.handle_mouse_drag_msg(*point),
             Message::MouseHover(point) => self.handle_mouse_drag_msg(*point),
             Message::MouseRelease => self.handle_mouse_release_msg(),
+            Message::DoubleClick(point) => self.handle_double_click_msg(*point),
+            Message::TripleClick(point) => self.handle_triple_click_msg(*point),
             Message::ContextMenuRequested(point) => {
                 self.handle_context_menu_requested_msg(*point)
             }


### PR DESCRIPTION
### Features Added

* Added **double-click** to select the word under the cursor.
* Added **triple-click** to select the entire line.
* Click count is detected based on **time (400ms)** and **cursor position (6px)**, similar to VS Code and native editors.
* Word selection uses the editor's existing word boundary helpers, keeping behavior consistent across the editor.

### Bug Fixed

Fixed an issue where clicking to place the cursor and then editing (Backspace, Delete, typing, Tab, or Paste) could leave a stale selection anchor.

This could create an invisible one-character selection, causing the next edit to delete an extra character unexpectedly.

The fix clears the selection anchor before moving the cursor when there is no active selection, making the behavior consistent with the existing Enter key implementation.
